### PR TITLE
Adding parameter to exclude source files from parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,12 @@ Make sure your Go environment is configured correctly, then run:
 
 ## Usage
 
-```godocjson <directory>```
+```godocjson [-e <pattern>] <directory>```
+
+The **godocjson** scans <directory> for Go packages and outputs JSON-formatted documentation to stdout
+
+The options are as follows:
+
+    -e   <pattern>   Exclude files that match specified pattern from processing.
+                     Example usage:
+                        godocjson -e _test.go ./go/sources/folder


### PR DESCRIPTION
Motivation to have the ability to exclude files:

1. If you have test files inside your package folder but want to exclude it
2. If you have to build separated public/private docs with CI and need to manage which files to parse
3. If you have multiple packages defined in your source folder - common for test files